### PR TITLE
Fix Compiler Warnings: piping into a function call without parentheses

### DIFF
--- a/lib/dmarc.ex
+++ b/lib/dmarc.ex
@@ -16,8 +16,8 @@ defmodule DMARC do
        _,["!"<>_|_] -> false                                           # 
        x,y -> length(x) > length(y)                                    # else priority to longest prefix match 
      end)
-  |> Enum.each fn spec->
-    org_match = (spec|>Enum.reverse|>Enum.map fn
+  |> Enum.each (fn spec->
+    org_match = (spec|>Enum.reverse|>Enum.map (fn
       "!"<>rest->rest  # remove exception mark ! 
       "*"->quote do: _ # "*" component matches anything, so convert it to "_"
       x -> x           # match other components as they are
@@ -25,7 +25,7 @@ defmodule DMARC do
     org_len = length(spec) + 1      # and 3+1=4 first components is organization
     def organization(unquote(org_match)=host), do:
       (host |> Enum.take(unquote(org_len)) |> Enum.reverse |> Enum.join("."))
-  end
+  end)
 
   def organization([unknown_tld,org|_]), do:
     "#{org}.#{unknown_tld}"

--- a/lib/dmarc.ex
+++ b/lib/dmarc.ex
@@ -21,7 +21,7 @@ defmodule DMARC do
       "!"<>rest->rest  # remove exception mark ! 
       "*"->quote do: _ # "*" component matches anything, so convert it to "_"
       x -> x           # match other components as they are
-    end) ++ quote do: [_org|_rest]  # ["com","*","pref"] -> must match ["com",_,"pref",_org|_rest]
+    end)) ++ quote do: [_org|_rest]  # ["com","*","pref"] -> must match ["com",_,"pref",_org|_rest]
     org_len = length(spec) + 1      # and 3+1=4 first components is organization
     def organization(unquote(org_match)=host), do:
       (host |> Enum.take(unquote(org_len)) |> Enum.reverse |> Enum.join("."))

--- a/lib/mime_types.ex
+++ b/lib/mime_types.ex
@@ -168,8 +168,8 @@ defmodule EBML do
     _ -> File.read!("#{:code.priv_dir(:mailibex)}/ebml.xml")
   end 
   Regex.scan(~r/<element [^>]*name="([^"]*)"[^>]* id="0x([^"]*)"[^>]* type="([^"]*)"[^>]*>/,ebml_spec) #"
-  |> Enum.each fn [_,key,hexkey,type]->
+  |> Enum.each (fn [_,key,hexkey,type]->
     def key_of(unquote(hexkey)), do: {unquote(key),unquote(:"#{type}")}
-  end
+  end)
 end
 


### PR DESCRIPTION
Fix compiler warnings for piping into a function call without parentheses.