### PR TITLE
Handle encoding type in lower case

### DIFF
--- a/lib/mimemail_headers.ex
+++ b/lib/mimemail_headers.ex
@@ -110,10 +110,10 @@ defmodule MimeMail.Words do
 
   def single_word_decode("=?"<>rest = str) do
     case String.split(rest,"?") do
-      [enc,"Q",enc_str,"="] ->
+      [enc,enc_type,enc_str,"="] when enc_type in ~w(q Q) ->
         str = q_to_binary(enc_str,[])
         MimeMail.ok_or(Iconv.conv(str,enc,"utf8"),MimeMail.ensure_ascii(str))
-      [enc,"B",enc_str,"="] ->
+      [enc,enc_type,enc_str,"="] when enc_type in ~w(b B)->
         str = Base.decode64(enc_str) |> MimeMail.ok_or(enc_str)
         MimeMail.ok_or(Iconv.conv(str,enc,"utf8"),MimeMail.ensure_ascii(str))
       _ -> "#{str} "

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,6 @@
 defmodule Mix.Tasks.Compile.Iconv do
+  use Mix.Task
+
   @shortdoc "Compiles Iconv"
   @doc """
   For Linux:
@@ -36,10 +38,10 @@ defmodule Mailibex.Mixfile do
     [app: :mailibex,
      version: "0.1.2",
      elixir: "> 1.0.0",
-     description: description,
-     package: package,
+     description: description(),
+     package: package(),
      compilers: [:iconv, :elixir, :app],
-     deps: deps]
+     deps: deps()]
   end
 
   def application do

--- a/test/mime_headers_test.exs
+++ b/test/mime_headers_test.exs
@@ -42,11 +42,15 @@ defmodule MimeHeadersTest do
   test "decode str from base 64 encoded-word" do
     assert "Jérôme Nicolle"
            = MimeMail.Words.word_decode("=?UTF-8?B?SsOpcsO0bWUgTmljb2xsZQ==?=")
+    assert "Jérôme Nicolle"
+           = MimeMail.Words.word_decode("=?utf-8?b?SsOpcsO0bWUgTmljb2xsZQ==?=")
   end
 
   test "decode str from q-encoded-word" do
     assert "[FRnOG] [TECH] ToS implémentée chez certains transitaires" 
            = MimeMail.Words.word_decode("[FRnOG] =?UTF-8?Q?=5BTECH=5D_ToS_impl=C3=A9ment=C3=A9e_chez_certa?=\r\n =?UTF-8?Q?ins_transitaires?=")
+    assert "[FRnOG] [TECH] ToS implémentée chez certains transitaires"
+           = MimeMail.Words.word_decode("[FRnOG] =?utf-8?q?=5BTECH=5D_ToS_impl=C3=A9ment=C3=A9e_chez_certa?=\r\n =?utf-8?q?ins_transitaires?=")
   end
 
   test "encode str into multiple encoded-word, test line length and round trip" do


### PR DESCRIPTION
- Fix compiler warnings from mix.ex
- Handle encoded words with `=?charset?[bq]?encoded text?=`.